### PR TITLE
Fix #959: Configurable User-Agent with versioned default

### DIFF
--- a/wdtk-wikibaseapi/pom.xml
+++ b/wdtk-wikibaseapi/pom.xml
@@ -15,6 +15,10 @@
 	<name>Wikidata Toolkit Wikibase API</name>
 	<description>Java library to access the Wikibase Web API</description>
 
+    <properties>
+        <user.agent>Wikidata-Toolkit/${project.version} (+https://github.com/Wikidata-Toolkit/Wikidata-Toolkit)</user.agent>
+    </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -52,5 +56,14 @@
 		</dependency>
 
 	</dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 
 </project>

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -108,6 +108,7 @@ public class BasicApiConnection extends ApiConnection {
 	@Override
 	protected OkHttpClient.Builder getClientBuilder() {
 		return new OkHttpClient.Builder()
+                .addInterceptor(new UserAgentInterceptor(customUserAgent))
 				.cookieJar(new JavaNetCookieJar(cookieManager));
 	}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnection.java
@@ -123,6 +123,7 @@ public class OAuthApiConnection extends ApiConnection {
         OkHttpOAuthConsumer consumer = new OkHttpOAuthConsumer(consumerKey, consumerSecret);
         consumer.setTokenWithSecret(accessToken, accessSecret);
         return new OkHttpClient.Builder()
+                .addInterceptor(new UserAgentInterceptor(customUserAgent))
                 .addInterceptor(new SigningInterceptor(consumer));
     }
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/UserAgentInterceptor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/UserAgentInterceptor.java
@@ -1,0 +1,43 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+public class UserAgentInterceptor implements Interceptor {
+
+    private final String userAgent;
+
+    public UserAgentInterceptor(String userAgent) {
+       this.userAgent = userAgent;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request().newBuilder()
+                .header("User-Agent", userAgent)
+                .build());
+    }
+
+}

--- a/wdtk-wikibaseapi/src/main/resources/wikidata-tk-http.properties
+++ b/wdtk-wikibaseapi/src/main/resources/wikidata-tk-http.properties
@@ -1,0 +1,1 @@
+user.agent=${user.agent}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -66,7 +66,7 @@ public class BasicApiConnectionTest {
 	private static MockWebServer server;
 	private BasicApiConnection connection;
 
-	private String LOGGED_IN_SERIALIZED_CONNECTION = "{\"baseUrl\":\"" + server.url("/w/api.php") + "\",\"cookies\":[{\"name\":\"GeoIP\",\"value\":\"DE:13:Dresden:51.0500:13.7500:v4\",\"comment\":null,\"commentURL\":null,\"domain\":\"domain comparison should be skipped\",\"maxAge\":-1,\"path\":\"/\",\"portlist\":null,\"secure\":false,\"httpOnly\":false,\"version\":0,\"discard\":false},{\"name\":\"testwikidatawikiSession\",\"value\":\"c18ef92637227283bcda73bcf95cfaf5\",\"comment\":null,\"commentURL\":null,\"domain\":\"domain comparison should be skipped\",\"maxAge\":-1,\"path\":\"/\",\"portlist\":null,\"secure\":true,\"httpOnly\":true,\"version\":0,\"discard\":false}],\"username\":\"username\",\"loggedIn\":true,\"tokens\":{\"login\":\"b5780b6e2f27e20b450921d9461010b4\"},\"connectTimeout\":5000,\"readTimeout\":6000}";
+	private String LOGGED_IN_SERIALIZED_CONNECTION = "{\"baseUrl\":\"" + server.url("/w/api.php") + "\",\"cookies\":[{\"name\":\"GeoIP\",\"value\":\"DE:13:Dresden:51.0500:13.7500:v4\",\"comment\":null,\"commentURL\":null,\"domain\":\"domain comparison should be skipped\",\"maxAge\":-1,\"path\":\"/\",\"portlist\":null,\"secure\":false,\"httpOnly\":false,\"version\":0,\"discard\":false},{\"name\":\"testwikidatawikiSession\",\"value\":\"c18ef92637227283bcda73bcf95cfaf5\",\"comment\":null,\"commentURL\":null,\"domain\":\"domain comparison should be skipped\",\"maxAge\":-1,\"path\":\"/\",\"portlist\":null,\"secure\":true,\"httpOnly\":true,\"version\":0,\"discard\":false}],\"username\":\"username\",\"loggedIn\":true,\"tokens\":{\"login\":\"b5780b6e2f27e20b450921d9461010b4\"},\"connectTimeout\":5000,\"readTimeout\":6000,\"customUserAgent\":\"customAgent\"}";
 
 	Set<String> split(String str, char ch) {
 		Set<String> set = new TreeSet<>();
@@ -205,6 +205,7 @@ public class BasicApiConnectionTest {
 		connection.login("username", "password");
 		connection.setConnectTimeout(5000);
 		connection.setReadTimeout(6000);
+        connection.setCustomUserAgent("customAgent");
 		assertTrue(connection.isLoggedIn());
 		String jsonSerialization = mapper.writeValueAsString(connection);
 		// We skip comparing the cookie domains here, since they depend on

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
@@ -72,7 +72,8 @@ public class OAuthApiConnectionTest {
             "\"loggedIn\":true," +
             "\"tokens\":{}," +
             "\"connectTimeout\":-1," +
-            "\"readTimeout\":-1}";
+            "\"readTimeout\":-1," +
+            "\"customUserAgent\":\"customAgent\"}";
 
     @BeforeClass
     public static void init() throws IOException {
@@ -109,6 +110,7 @@ public class OAuthApiConnectionTest {
     public void setUp() {
         connection = new OAuthApiConnection(server.url("/w/api.php").toString(),
                 CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_SECRET);
+        connection.setCustomUserAgent("customAgent");
     }
 
     @Test


### PR DESCRIPTION
This PR introduces support for configuring a custom User-Agent header in HTTP requests.
When no custom User-Agent is defined, the library now falls back to a meaningful default.

I verified the change with one of our applications:

On versions prior to **0.16.1-SNAPSHOT**, the issue described in #959 happens.

Using a SNAPSHOT built from this branch, the behavior works correctly for my tested use case.