### PR TITLE
Support Jackson 3.2 snak type serialization

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Antonin Delpeuch
  *
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "snaktype")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "snaktype")
 @JsonSubTypes({
 		@Type(value = NoValueSnakImpl.class, name = SnakImpl.JSON_SNAK_TYPE_NOVALUE),
 		@Type(value = SomeValueSnakImpl.class, name = SnakImpl.JSON_SNAK_TYPE_SOMEVALUE),


### PR DESCRIPTION
## Summary

- adapt `SnakImpl` type metadata to Jackson 3.2's handling of an already serialized discriminator
- keep `snaktype` as the existing JSON property instead of asking Jackson to emit a duplicate type id
- preserve the current JSON shape and deserialization behavior

This is a companion fix for Dependabot PR #1016 and targets its exact head (`71c7eb0e135419c308a21513bccb613f8e24bb61`). That upgrade fails because Jackson 3.2 rejects the duplicate `snaktype` type id/property and recommends `JsonTypeInfo.As.EXISTING_PROPERTY`.

## Verification

- JAIPilot Remote, Temurin 21: `mvn --batch-mode --no-transfer-progress -Dgpg.skip=true -Dstyle.color=never -pl wdtk-datamodel -am test` — 803 tests passed across the four-module affected reactor, with no failures, errors, or skips
- local OpenJDK 25: the repository's full 10-module CI command (`jacoco:prepare-agent verify jacoco:report`) completed successfully
- a clean remote full-reactor run passed the affected modules, then encountered two unrelated assertions in the live Wikimedia dump-list test; no test or quality gate was disabled
- final diff: one production annotation argument changed; `git diff --check` passes

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
